### PR TITLE
Fix time zone month calculation

### DIFF
--- a/src/main/java/com/github/msemitkin/financie/timezone/TimeZoneUtils.java
+++ b/src/main/java/com/github/msemitkin/financie/timezone/TimeZoneUtils.java
@@ -34,8 +34,10 @@ public class TimeZoneUtils {
     }
 
     public static LocalDateTime getUTCStartOfTheMonthInTimeZone(YearMonth yearMonth, ZoneId zoneId) {
-        OffsetDateTime startOfTheMonth = OffsetDateTime
-            .of(yearMonth.getYear(), yearMonth.getMonthValue(), 1, 0, 0, 0, 0, ZoneOffset.of(zoneId.getId()));
-        return LocalDateTime.ofInstant(startOfTheMonth.toInstant(), ZoneId.of("UTC"));
+        return yearMonth
+            .atDay(1)
+            .atStartOfDay(zoneId)
+            .withZoneSameInstant(ZoneOffset.UTC)
+            .toLocalDateTime();
     }
 }

--- a/src/main/java/com/github/msemitkin/financie/timezone/TimeZoneUtils.java
+++ b/src/main/java/com/github/msemitkin/financie/timezone/TimeZoneUtils.java
@@ -2,11 +2,9 @@ package com.github.msemitkin.financie.timezone;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
 import java.time.YearMonth;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.time.temporal.TemporalAdjusters;
 
 public class TimeZoneUtils {
     private TimeZoneUtils() {
@@ -24,13 +22,7 @@ public class TimeZoneUtils {
     }
 
     public static LocalDateTime getUTCStartOfTheMonthInTimeZone(ZoneId zoneId) {
-        OffsetDateTime startOfTheMonth = OffsetDateTime.now(zoneId)
-            .with(TemporalAdjusters.firstDayOfMonth())
-            .withHour(0)
-            .withMinute(0)
-            .withSecond(0)
-            .withNano(0);
-        return LocalDateTime.ofInstant(startOfTheMonth.toInstant(), ZoneId.of("UTC"));
+        return getUTCStartOfTheMonthInTimeZone(YearMonth.now(zoneId), zoneId);
     }
 
     public static LocalDateTime getUTCStartOfTheMonthInTimeZone(YearMonth yearMonth, ZoneId zoneId) {

--- a/src/test/java/com/github/msemitkin/financie/timezone/TimeZoneUtilsTest.java
+++ b/src/test/java/com/github/msemitkin/financie/timezone/TimeZoneUtilsTest.java
@@ -1,0 +1,28 @@
+package com.github.msemitkin.financie.timezone;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+class TimeZoneUtilsTest {
+
+    @Test
+    void startOfMonthForZoneIdIsConvertedToUtc() {
+        ZoneId zoneId = ZoneId.of("Europe/Berlin");
+        YearMonth yearMonth = YearMonth.of(2024, 2);
+
+        LocalDateTime expected = yearMonth
+            .atDay(1)
+            .atStartOfDay(zoneId)
+            .withZoneSameInstant(ZoneOffset.UTC)
+            .toLocalDateTime();
+
+        LocalDateTime actual = TimeZoneUtils.getUTCStartOfTheMonthInTimeZone(yearMonth, zoneId);
+
+        Assertions.assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/com/github/msemitkin/financie/timezone/TimeZoneUtilsTest.java
+++ b/src/test/java/com/github/msemitkin/financie/timezone/TimeZoneUtilsTest.java
@@ -1,25 +1,34 @@
 package com.github.msemitkin.financie.timezone;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
+import java.util.stream.Stream;
 
 class TimeZoneUtilsTest {
 
-    @Test
-    void startOfMonthForZoneIdIsConvertedToUtc() {
-        ZoneId zoneId = ZoneId.of("Europe/Berlin");
-        YearMonth yearMonth = YearMonth.of(2024, 2);
+    static Stream<Arguments> monthAndExpectedUtc() {
+        return Stream.of(
+            org.junit.jupiter.params.provider.Arguments.of(
+                YearMonth.of(2024, 2), // Before DST
+                LocalDateTime.of(2024, 1, 31, 23, 0)
+            ),
+            org.junit.jupiter.params.provider.Arguments.of(
+                YearMonth.of(2024, 7), // During DST
+                LocalDateTime.of(2024, 6, 30, 22, 0)
+            )
+        );
+    }
 
-        LocalDateTime expected = yearMonth
-            .atDay(1)
-            .atStartOfDay(zoneId)
-            .withZoneSameInstant(ZoneOffset.UTC)
-            .toLocalDateTime();
+    @ParameterizedTest
+    @MethodSource("monthAndExpectedUtc")
+    void getUTCStartOfTheMonthInTimeZone_shouldBeConvertedToUtc_regardlessOfDst(YearMonth yearMonth, LocalDateTime expected) {
+        ZoneId zoneId = ZoneId.of("Europe/Berlin");
 
         LocalDateTime actual = TimeZoneUtils.getUTCStartOfTheMonthInTimeZone(yearMonth, zoneId);
 


### PR DESCRIPTION
## Summary
- fix `getUTCStartOfTheMonthInTimeZone` to handle region IDs
- add regression test for `TimeZoneUtils`

## Testing
- `./gradlew test --info`

------
https://chatgpt.com/codex/tasks/task_e_68403ed44a5c832782b49cfac5bdb0d0